### PR TITLE
Add WordPress filter for the lowest price

### DIFF
--- a/app/PriorPrice/Prices.php
+++ b/app/PriorPrice/Prices.php
@@ -92,7 +92,7 @@ class Prices {
 			$lowest = $this->history_storage->get_minimal( $wc_product->get_id(), $days_number );
 		}
 
-		$lowest = $this->taxes->apply_taxes( $lowest, $wc_product );
+        $lowest = apply_filters('wc_price_history_lowest_price', $this->taxes->apply_taxes( $lowest, $wc_product ), $wc_product);
 
 		if ( (float) $lowest <= 0 ) {
 			return '';


### PR DESCRIPTION
Hi,

First of all, thank you for this amazing plugin.

This PR adds WordPress filter for the lowest price allowing to alter it just before showing. For example, this alows converting the lowest price to the currently selected currency, when using mulitcurency plugin.