### PR TITLE
Allow to decide what to display in case there was no price change in the tracked history span. (#77)

### DIFF
--- a/app/PriorPrice/SettingsData.php
+++ b/app/PriorPrice/SettingsData.php
@@ -48,6 +48,12 @@ class SettingsData {
 			$update                   = true;
 		}
 
+		if ( ! isset( $settings['old_history'] ) ) {
+			$settings['old_history']             = 'custom_text'; // 'hide', 'current_price', 'custom_text'
+			$settings['old_history_custom_text'] = esc_html__( 'Price in the last {days} days is the same as current', 'wc-price-history' );
+			$update                              = true;
+		}
+
 		if ( $update ) {
 			update_option( 'wc_price_history_settings', $settings );
 		}
@@ -150,5 +156,37 @@ class SettingsData {
 			return false;
 		}
 		return (bool) $settings['display_line_through'];
+	}
+
+	/**
+	 * Get old history setting.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @return string
+	 */
+	public function get_old_history() : string {
+
+		$settings = get_option( 'wc_price_history_settings' );
+		if ( ! isset( $settings['old_history'] ) ) {
+			return 'hide';
+		}
+		return $settings['old_history'];
+	}
+
+	/**
+	 * Get old history custom text setting.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @return string
+	 */
+	public function get_old_history_custom_text() : string {
+
+		$settings = get_option( 'wc_price_history_settings' );
+		if ( ! isset( $settings['old_history_custom_text'] ) ) {
+			return esc_html__( 'Price in the last {days} days is the same as current', 'wc-price-history' );
+		}
+		return esc_html( $settings['old_history_custom_text'] );
 	}
 }

--- a/app/PriorPrice/SettingsPage.php
+++ b/app/PriorPrice/SettingsPage.php
@@ -217,7 +217,7 @@ class SettingsPage {
 												value="sale_start_inclusive"
 												<?php checked( isset( $settings['count_from'] ) ? $settings['count_from'] : false, 'sale_start_inclusive' ); ?>
 											/>
-											<?php esc_html_e( 'Day when product product went on sale (includes promotional price)', 'wc-price-history' ); ?>
+											<?php esc_html_e( 'Day when product went on sale (includes promotional price)', 'wc-price-history' ); ?>
 										</label>
 									</p>
 									<p class="description">
@@ -248,6 +248,7 @@ class SettingsPage {
 											<input
 												type="number"
 												name="wc_price_history_settings[days_number]"
+												id="wc-price-history-days-number"
 												value="<?php echo isset( $settings['days_number'] ) ? $settings['days_number'] : 30; ?>"
 											/>
 											<?php esc_attr_e( 'days', 'wc-price-history' ) ?></label>
@@ -263,18 +264,88 @@ class SettingsPage {
 							<td>
 								<fieldset>
 									<p>
-										<label>
+										<label class="wc-price-history-wide-field">
 											<input
 												type="text"
 												name="wc_price_history_settings[display_text]"
+												class="wc-price-history-wide-field"
 												<?php /* translators: Do not translate {price}, it is template slug! */ ?>
-												value="<?php echo isset( $settings['display_text'] ) ? $settings['display_text'] : __( '30-day low: {price}', 'wc-price-history' ); ?>"
+												value="<?php echo isset( $settings['display_text'] ) ? $settings['display_text'] : esc_html__( '30-day low: {price}', 'wc-price-history' ); ?>"
 											/>
 										</label>
 									</p>
 									<p class="description" >
 										<?php /* translators: Do not translate {price} and {days}, those are template slugs! */ ?>
 										<?php esc_html_e( 'Use placeholder {price} to display price and {days} to display number of days.', 'wc-price-history' ); ?>
+									</p>
+								</fieldset>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<?php
+									printf(
+										/* translators: %s: {days-set} template slug */
+										esc_html__( 'What to do when price history is older than %s days:', 'wc-price-history' ),
+										'<span class="wc-price-history-days-set">' . $settings['days_number'] . '</span>'
+										);
+								?>
+							</th>
+							<td>
+								<fieldset id="wc-price-history-old-history-fieldset">
+									<p class="description" >
+										<?php
+											printf(
+												/* translators: Do not translate {days-set}, it is template slug! */
+												esc_html__( 'It could happen that the last change of price was more than %s days ago. In that case you can choose to hide minimal price, display current price or display custom text.', 'wc-price-history' ),
+												'<span class="wc-price-history-days-set">' . $settings['days_number'] . '</span>'
+											);
+										?>
+									</p>
+									<p>
+										<label>
+											<input
+												type="radio"
+												name="wc_price_history_settings[old_history]"
+												value="hide"
+												<?php checked( isset( $settings['old_history'] ) ? $settings['old_history'] : false, 'hide' ); ?>
+											/>
+											<?php esc_html_e( 'Hide minimal price', 'wc-price-history' ); ?>
+										</label>
+										<br />
+										<label>
+											<input
+												type="radio"
+												name="wc_price_history_settings[old_history]"
+												value="current_price"
+												<?php checked( isset( $settings['old_history'] ) ? $settings['old_history'] : false, 'current_price' ); ?>
+											/>
+											<?php esc_html_e( 'Display current price', 'wc-price-history' ); ?>
+										</label>
+										<br />
+										<label>
+											<input
+												type="radio"
+												name="wc_price_history_settings[old_history]"
+												value="custom_text"
+												<?php checked( isset( $settings['old_history'] ) ? $settings['old_history'] : false, 'custom_text' ); ?>
+											/>
+											<?php esc_html_e( 'Display custom text', 'wc-price-history' ); ?>:
+										</label>
+									</p>
+									<p class="wc-price-history-old-history-custom-text-p <?php echo isset( $settings['old_history'] ) && $settings['old_history'] === 'custom_text' ? '' : 'hidden-fade'; ?>">
+										<label class="wc-price-history-wide-field">
+											<input
+												type="text"
+												name="wc_price_history_settings[old_history_custom_text]"
+												class="wc-price-history-wide-field"
+												<?php /* translators: Do not translate {days}, it is template slug! */ ?>
+												value="<?php echo isset( $settings['old_history_custom_text'] ) ? $settings['old_history_custom_text'] : esc_html__( 'Price in the last {days} days is the same as current', 'wc-price-history' ); ?>"
+											/>
+										</label>
+									</p>
+									<p class="description wc-price-history-old-history-custom-text-p <?php echo isset( $settings['old_history'] ) && $settings['old_history'] === 'custom_text' ? '' : 'hidden-fade'; ?>">
+										<?php esc_html_e( 'If you choose to display custom text, use placeholder {days} to display number of days and {price} to display current price.', 'wc-price-history' ); ?>
 									</p>
 								</fieldset>
 							</td>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,19 @@
 
+.wc-price-history-wide-field {
+	width: 90%;
+}
+
+.wc-price-history-old-history-custom-text-p {
+	opacity: 1;
+	height: 100%;
+	overflow: hidden;
+	transition: opacity 0.5s, height 0.5s;
+}
+
+.wc-price-history-old-history-custom-text-p.hidden-fade {
+	opacity: 0;
+	height: 0;
+}
 
 .wc-history-price-admin__left {
 	float: left;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,2 +1,27 @@
 jQuery(document).ready(function($) {
+
+	// Toggle the custom text field when the custom text radio button is selected.
+	$( '#wc-price-history-old-history-fieldset input' ).on(
+		'change',
+		function() {
+			if ( $( '#wc-price-history-old-history-fieldset input:checked' ).val() == 'custom_text' ) {
+				$( '.wc-price-history-old-history-custom-text-p' ).removeClass( 'hidden-fade' );
+			} else {
+				$( '.wc-price-history-old-history-custom-text-p' ).addClass( 'hidden-fade' );
+			}
+		}
+	);
+
+	// There are tesxts like "What to do when price history is older than {days-set} days" on the page's HTML code.
+	// copy value from input field #wc-price-history-days-number to every place on page where is {days-set} placeholder in pages HTML (replace it).
+	$( '#wc-price-history-days-number' ).on(
+		'input',
+		function() {
+			$( '.wc-price-history-days-set' ).each(
+				function() {
+					$( this ).text( $( '#wc-price-history-days-number' ).val() );
+				}
+			);
+		}
+	);
 });

--- a/languages/wc-price-history.pot
+++ b/languages/wc-price-history.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the WC Price History plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Price History 1.7.1\n"
+"Project-Id-Version: WC Price History 1.9.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wc-price-history\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-02-19T17:13:01+01:00\n"
+"POT-Creation-Date: 2023-12-16T13:38:22+01:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: wc-price-history\n"
@@ -23,11 +23,15 @@ msgid "https://github.com/kkarpieszuk/wc-price-history"
 msgstr ""
 
 #. Description of the plugin
-msgid "Track WooCommerce© Products prior prices history and display the lowest price in the last 30 days. This plugin allows your WC shop to be compliant with European Commission Directive 98/6/EC Article 6a which specifies price reduction announcement policy."
+msgid "Track WooCommerce Products prior prices history and display the lowest price in the last 30 days (fully configurable). This plugin allows your WC shop to be compliant with European Commission Directive 98/6/EC Article 6a which specifies price reduction announcement policy."
 msgstr ""
 
 #. Author of the plugin
 msgid "Konrad Karpieszuk"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://wpzlecenia.pl"
 msgstr ""
 
 #. translators: %d product id, %s link to product edit screen.
@@ -42,12 +46,19 @@ msgstr ""
 
 #. translators: Do not translate {price}, it is template slug!
 #: app/PriorPrice/SettingsData.php:47
-#: app/PriorPrice/SettingsPage.php:271
+#: app/PriorPrice/SettingsPage.php:273
 msgid "30-day low: {price}"
 msgstr ""
 
+#. translators: Do not translate {days}, it is template slug!
+#: app/PriorPrice/SettingsData.php:53
+#: app/PriorPrice/SettingsData.php:188
+#: app/PriorPrice/SettingsPage.php:343
+msgid "Price in the last {days} days is the same as current"
+msgstr ""
+
 #. translators: %s - the lowest price in the last 30 days.
-#: app/PriorPrice/SettingsData.php:132
+#: app/PriorPrice/SettingsData.php:138
 msgid "30-day low: %s"
 msgstr ""
 
@@ -126,7 +137,7 @@ msgid "Day before product went on sale (excludes promotional price)"
 msgstr ""
 
 #: app/PriorPrice/SettingsPage.php:220
-msgid "Day when product product went on sale (includes promotional price)"
+msgid "Day when product went on sale (includes promotional price)"
 msgstr ""
 
 #: app/PriorPrice/SettingsPage.php:224
@@ -154,55 +165,81 @@ msgstr ""
 msgid "Number of days to use when counting minimal price:"
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:253
+#: app/PriorPrice/SettingsPage.php:254
 msgid "days"
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:256
+#: app/PriorPrice/SettingsPage.php:257
 msgid "Omnibus: European Union Guidance requires displaying lowest price from the last 30 days."
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:262
+#: app/PriorPrice/SettingsPage.php:263
 msgid "Minimal price text:"
 msgstr ""
 
 #. translators: Do not translate {price} and {days}, those are template slugs!
-#: app/PriorPrice/SettingsPage.php:277
+#: app/PriorPrice/SettingsPage.php:279
 msgid "Use placeholder {price} to display price and {days} to display number of days."
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:283
+#. translators: %s: {days-set} template slug
+#: app/PriorPrice/SettingsPage.php:289
+msgid "What to do when price history is older than %s days:"
+msgstr ""
+
+#. translators: Do not translate {days-set}, it is template slug!
+#: app/PriorPrice/SettingsPage.php:300
+msgid "It could happen that the last change of price was more than %s days ago. In that case you can choose to hide minimal price, display current price or display custom text."
+msgstr ""
+
+#: app/PriorPrice/SettingsPage.php:313
+msgid "Hide minimal price"
+msgstr ""
+
+#: app/PriorPrice/SettingsPage.php:323
+msgid "Display current price"
+msgstr ""
+
+#: app/PriorPrice/SettingsPage.php:333
+msgid "Display custom text"
+msgstr ""
+
+#: app/PriorPrice/SettingsPage.php:348
+msgid "If you choose to display custom text, use placeholder {days} to display number of days and {price} to display current price."
+msgstr ""
+
+#: app/PriorPrice/SettingsPage.php:354
 msgid "When displaying minimal price:"
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:294
+#: app/PriorPrice/SettingsPage.php:365
 msgid "Apply line-through on the price"
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:298
+#: app/PriorPrice/SettingsPage.php:369
 msgid "If checked, price will be displayed with line-through on it."
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:309
+#: app/PriorPrice/SettingsPage.php:380
 msgid "Read the EU legal acts:"
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:311
+#: app/PriorPrice/SettingsPage.php:382
 msgid "Guidance on the Price Indication Directive (2021)"
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:314
+#: app/PriorPrice/SettingsPage.php:385
 msgid "Support"
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:317
+#: app/PriorPrice/SettingsPage.php:388
 msgid "If you have any questions, please contact me at plugin support forum."
 msgstr ""
 
-#: app/PriorPrice/SettingsPage.php:321
+#: app/PriorPrice/SettingsPage.php:392
 msgid "Please rate the plugin! "
 msgstr ""
 
-#: plugin.php:25
+#: plugin.php:26
 msgid "WooCommerce Price History plugin requires WooCommerce to be installed and active."
 msgstr ""

--- a/plugin.php
+++ b/plugin.php
@@ -1,9 +1,10 @@
 <?php
 /*
  * Plugin Name: WC Price History
- * Description: Track WooCommerce© Products prior prices history and display the lowest price in the last 30 days. This plugin allows your WC shop to be compliant with European Commission Directive 98/6/EC Article 6a which specifies price reduction announcement policy.
+ * Description: Track WooCommerce Products prior prices history and display the lowest price in the last 30 days (fully configurable). This plugin allows your WC shop to be compliant with European Commission Directive 98/6/EC Article 6a which specifies price reduction announcement policy.
  * Author: Konrad Karpieszuk
- * Version: 1.8.1
+ * Author URI: https://wpzlecenia.pl
+ * Version: 1.9.0
  * Text Domain: wc-price-history
  * Domain Path: /languages/
  * Requires at least: 5.8

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: WooCommerce, prices, history, prior, omnibus, european, 30days
 Requires at least: 5.8
 Tested up to: 6.4.1
 Requires PHP: 7.2
-Stable tag: 1.8.1
+Stable tag: 1.9.0
 License: MIT License
 License URI: https://mit-license.org/
 Donate link: https://buycoffee.to/wpzlecenia
@@ -35,6 +35,7 @@ Plugin is configurable via `WooCommerce` > `Price History` screen. You can confi
 &#8618; How to count minimal price (the minimal from the moment product went on sale to 30 days before that moment or the minimal price from today to 30 days ago)
 &#8618; How many days take into account when calculating minimal price (30 days by default)
 &#8618; How to display the price history information
+&#8618; What to do if the price didn't change in the last N days (hide price information / display current price / display custom text)
 
 At the configuration screen you will find additional information how to configure the plugin to be compliant with Omnibus directive (European Commission Directive 98/6/EC Article 6a) and link to legal acts.
 
@@ -111,6 +112,9 @@ add_filter( 'wc_price_history_lowest_price_html_raw_value_taxed', function( $pri
 Please submit the [GitHub issue](https://github.com/kkarpieszuk/wc-price-history/issues).
 
 == Changelog ==
+
+= 1.9.0 =
+* New: Allow to decide what to display in case there was no price change in the tracked history span. (#77)
 
 = 1.8.0 =
 * New: Basic compatibility with dynamic pricing plugins.


### PR DESCRIPTION
Fixes #77 